### PR TITLE
Spanish translations of basics' memory, type qualifiers and control flow

### DIFF
--- a/basics/basic-types.md
+++ b/basics/basic-types.md
@@ -93,7 +93,7 @@ Nota: las siguientes referencias están en inglés
 - [Propiedades de tipos](https://dlang.org/spec/property.html)
 - [Expresión assert](https://dlang.org/spec/expression.html#AssertExpression)
 
-## {Código fuente}
+## {SourceCode}
 
 ```d
 import std.stdio : writeln;

--- a/basics/controlling-flow.md
+++ b/basics/controlling-flow.md
@@ -1,0 +1,70 @@
+# Control de flujo
+
+El flujo de una aplicación puede ser controlado de forma condicional con las
+sentencias `if` y `else`:
+
+    if (a == 5) {
+        writeln("Condición satisfecha");
+    } else if (a > 10) {
+        writeln("Otra condición satisfecha");
+    } else {
+        writeln("¡Ninguna condición satisfecha!");
+    }
+
+Cuando un bloque `if` o un `else` sólo contiene una sentencia, se pueden
+omitir las llaves de apertura y cierre.
+
+D proporciona los mismos operadores que C/C++ y Java para comprobar la igualdad
+de variables o compararlas:
+
+* `==` y `!=` para comprobar la igualdad o desigualdad.
+* `<`, `<=`, `>` y `>=` para comprobar si es menor que (o menor o igual) y si es mayor que (o mayor o igual).
+
+Cuando se combinan varias condiciones se puede usar el operador `||` para
+representar un *O* lógico (*OR* en inglés) y `&&` para representar un *Y*
+lógico (*AND* en inglés).
+
+D también define una sentencia `switch`..`case` que ejecuta un caso dependiendo
+del valor de *una* variable. `switch` funciona con todos los tipos de datos
+básicos y ¡con cadenas de caracteres! Incluso es posible definir rangos para
+tipos de datos enteros usando la sintaxis `case START: .. case END:`. Asegúrate
+de echar un vistazo al código fuente de ejemplo.
+
+### En profundidad
+
+#### Referencias básicas
+
+- [Logical expressions in _Programming in D_](http://ddili.org/ders/d.en/logical_expressions.html)
+- [If statement in _Programming in D_](http://ddili.org/ders/d.en/if.html)
+- [Ternary expressions in _Programming in D_](http://ddili.org/ders/d.en/ternary.html)
+- [`switch` and `case` in _Programming in D_](http://ddili.org/ders/d.en/switch_case.html)
+
+#### Referencias avanzadas
+
+- [Expressions in detail](https://dlang.org/spec/expression.html)
+- [If Statement specification](https://dlang.org/spec/statement.html#if-statement)
+
+## {SourceCode}
+
+```d
+import std.stdio : writeln;
+
+void main()
+{
+    if (1 == 1)
+        writeln("¡Las mates en D funcionan!");
+
+    int c = 5;
+    switch(c) {
+        case 0: .. case 9:
+            writeln(c, " está entre 0-9");
+            break; // ¡necesario!
+        case 10:
+            writeln("¡Un diez!");
+            break;
+        default: // si nada coincide
+            writeln("Nada");
+            break;
+    }
+}
+```

--- a/basics/index.yml
+++ b/basics/index.yml
@@ -4,7 +4,7 @@ ordering:
 - basic-types
 - memory
 - type-qualifiers
-# - controlling-flow
+- controlling-flow
 # - functions
 # - structs
 # - arrays

--- a/basics/index.yml
+++ b/basics/index.yml
@@ -3,7 +3,7 @@ ordering:
 - imports-and-modules
 - basic-types
 - memory
-# - type-qualifiers
+- type-qualifiers
 # - controlling-flow
 # - functions
 # - structs

--- a/basics/index.yml
+++ b/basics/index.yml
@@ -1,8 +1,8 @@
-title: Las Bases de D
+title: Las bases de D
 ordering:
 - imports-and-modules
 - basic-types
-# - memory
+- memory
 # - type-qualifiers
 # - controlling-flow
 # - functions

--- a/basics/memory.md
+++ b/basics/memory.md
@@ -1,0 +1,66 @@
+# Memoria
+
+D es un lenguaje de programación de sistemas por lo que permite gestión de
+memoria manual. Sin embargo, gestionar la memoria de forma manual es muy
+propenso a errores, por lo que D usa de forma predeterminada un recolector
+de basura (*garbage collector* o *GC* en inglés) para gestionar la memoria.
+
+D tiene punteros, `T*`, igual que en C:
+
+    int a;
+    int* b = &a; // b contiene la dirección de memoria de a
+    auto c = &a; // c es int* y contiene la dirección de memoria de a
+
+Para asignar un nuevo bloque de memoria en el *heap* se usa la expresión
+`new`, que devuelve un puntero a la memoria reservada:
+
+    int* a = new int;
+
+Tan pronto como la memoria referenciada por `a` deja de estarlo, es decir, no es
+accesible a través de ninguna variable del programa, el recolector de basura
+libera dicha memoria.
+
+D tiene tres niveles de seguridad diferentes para las funciones: `@system`,
+`@trusted` y `@safe`. Si no se especifica ninguno, `@system` es el predeterminado.
+`@safe` es un subconjunto de D que evita errores de memoria por diseño.
+El código marcado como `@safe` sólo puede llamar a otro código marcado como
+`@safe` o como `@trusted`. Además, la aritmética de punteros explícita está
+prohibida en el código marcado como `@safe`:
+
+    void main() @safe {
+        int a = 5;
+        int* p = &a;
+        int* c = p + 5; // error
+    }
+
+El código marcado como `@trusted` es verificado manualmente y permite un puente
+entre el código marcado como `@safe` y el mundo de la programación de bajo nivel.
+
+### En profundidad
+
+* [SafeD](https://dlang.org/safed.html)
+
+## {SourceCode}
+
+```d
+import std.stdio : writeln;
+
+void safeFun() @safe
+{
+    writeln("Hola, mundo.");
+    // asignar memoria mediante el GC es seguro
+    int* p = new int;
+}
+
+void unsafeFun()
+{
+    int* p = new int;
+    int* fiddling = p + 5;
+}
+
+void main()
+{
+    safeFun();
+    unsafeFun();
+}
+```

--- a/basics/type-qualifiers.md
+++ b/basics/type-qualifiers.md
@@ -1,0 +1,115 @@
+# Mutabilidad
+
+D es un lenguaje de tipado estático: una vez que una variable ha sido declarada,
+su tipo no se puede cambiar desde ese momento en adelante. Esto permite al
+compilador evitar errores de forma temprana e imponer restricciones en tiempo
+de compilación. Una buena seguridad en los tipos aporta el apoyo que uno
+necesita para crear grandes programas más seguros y más mantenibles.
+
+Hay varios elementos para calificar los de tipos de datos en D, pero los más
+comunes son `const` e `inmmutable`.
+
+### `immutable`
+
+Junto con el sistema de tipado estático, D proporciona calificadores de tipos
+(*type qualifiers* en inglés), a veces llamados constructores de tipos que
+obligan a cumplir restricciones en ciertos objetos. Por ejemplo, un objeto
+`immutable` puede ser inicializado sólo una vez y, después de esta inicialización,
+ya no puede ser modificado.
+
+    immutable int err = 5;
+    // o: immutable err = 5 y su tipo, int, se infiere.
+    err = 5; // no compila
+
+Los objetos marcados con `immutable` pueden así ser puestos de forma segura en
+memoria compartida entre varios hilos sin necesidad de sincronización ya que
+estos nunca van a cambiar por definición. Esto también implica que los objetos
+marcados con `immutable` puede ser puestos perfectamente en memorias caché.
+
+### `const`
+
+Los objetos marcados con `const` tampoco pueden ser modificados. Pero esta
+restricción sólo se aplica al entorno actual. Un puntero marcado con `const`
+puede ser creado tanto desde un objeto *mutable* como de uno `inmmutable`.
+Esto significa que el objeto es `const` en el ámbito actual, pero alguien
+podría modificarlo desde un contexto diferente. Es común que las API acepten
+argumentos marcados con `const` para asegurarse que no se modifican dentro de
+la función, pero dicha función puede aceptar argumentos tanto de objetos 
+mutables como `inmutable`s.
+
+    void foo(const char[] s)
+    {
+        // si la siguiente línea no estuviera comentada, la
+        // compilación daría un error (no se puede modificar const):
+        // s[0] = 'x';
+
+        import std.stdio : writeln;
+        writeln(s);
+    }
+
+    // gracias a `const`, ambas llamadas compilan:
+    foo("abcd"); // string (cadena de caracteres) es un array inmutable
+    foo("abcd".dup); // .dup devuelve una copia mutable
+
+Tanto `immutable` como `const` son calificadores _transitivos_, es decir, cuando
+`const` se aplicado a un tipo de datos, este se aplicado recursivamente a cada
+subcomponente de dicho tipo.
+
+### En profundidad
+
+#### Referencias básicas
+
+- [Immutable in _Programming in D_](http://ddili.org/ders/d.en/const_and_immutable.html)
+- [Scopes in _Programming in D_](http://ddili.org/ders/d.en/name_space.html)
+
+#### Referencias avanzadas
+
+- [const(FAQ)](https://dlang.org/const-faq.html)
+- [Type qualifiers in D](https://dlang.org/spec/const3.html)
+
+## {SourceCode}
+
+```d
+import std.stdio : writeln;
+
+void main()
+{
+    /**
+    * Las variables con mutables de forma
+    * predeterminada y editarlas está
+    * permitido:
+    */
+    int m = 100; // mutable
+    writeln("m: ", typeof(m).stringof);
+    m = 10; // bien
+
+    /**
+    * Apuntando a memoria mutable:
+    */
+    // Un puntero constante a memoria mutable
+    // está permitido
+    const int* cm = &m;
+    writeln("cm: ", typeof(cm).stringof);
+    // Por definición, `const` no se puede
+    // modificar:
+    // *cm = 100; // error
+
+    // Como se garantiza que `immutable` va
+    // a permanecer sin cambios, este no puede
+    // apuntar a memoria mutable
+    // immutable int* im = &m; // error
+
+    /**
+    * Apuntando a memoria de sólo lectura:
+    */
+    immutable v = 100;
+    writeln("v: ", typeof(v).stringof);
+    // v = 5; // error
+
+    // `const` puede apuntar a memoria de sólo
+    // lectura, pero también es de sólo lectura
+    const int* cv = &v;
+    writeln("*cv: ", typeof(cv).stringof);
+    // *cv = 10; // error
+}
+```

--- a/welcome/index.yml
+++ b/welcome/index.yml
@@ -1,3 +1,6 @@
 title: Bienvenido
 ordering:
 - welcome-to-d
+- languages
+- install-d-locally
+- run-d-program-locally


### PR DESCRIPTION
Spanish translations of:
* memory
* type qualifiers
* control flow

Also, fix missing items in Welcome index.