### PR TITLE
consistency fix proposal

### DIFF
--- a/basics/type-qualifiers.md
+++ b/basics/type-qualifiers.md
@@ -107,7 +107,7 @@ void main() {
     // `const` puede apuntar a memoria de sólo
     // lectura, pero también es de sólo lectura
     const int* cv = &v;
-    writeln("*cv: ", typeof(cv).stringof);
+    writeln("cv: ", typeof(cv).stringof);
     // *cv = 10; // error
 }
 ```


### PR DESCRIPTION
This is not a translation problem, I think this is a small issue of consistency in the example that might confuse someone.

The example is about mutability qualifiers but also shows how to use the typeof( .. ).tostring() to obtain a human-readable string of that type. At line 18 it says:

    const int* cm = &m;
    writeln("cm: ", typeof(cm).stringof);

and few lines down (line 37) it says:

    const int* cv = &v;
    writeln("*cv: ", typeof(cv).stringof);

there is no consistency between the two sections of the example. If the first writln text is correct then the text of the second writeln should say "cv" and not "\*cv". You know, the output of typeof(\*cv).stringof is not the same that typeof(cv).stringof, like "\*cv: const(int*)" is not the same that "cv: const(int*)".

Assuming that the * must be removed from the second writeln, I just sent a merge request with this proposal. This issue also exists in the main version of the tour. I will propose the same change there if you all agree with it.